### PR TITLE
Refactor: ocean_model and time_varname as class attributes.

### DIFF
--- a/crococamp/model_adapter/model_adapter.py
+++ b/crococamp/model_adapter/model_adapter.py
@@ -27,20 +27,30 @@ class ModelAdapter(ABC):
     """Base class for all model normalizations
 
     Provides common functionality for model input normalization.
+    
+    Class attributes:
+        ocean_model: Name of the ocean model. Subclasses must define this.
+        time_varname: Name of the time variable in model files. Subclasses must define this.
+        capabilities: Model-specific capabilities configuration.
     """
-
-    # run arguments
+    ocean_model: str
+    time_varname: str
     capabilities: ModelAdapterCapabilities = ModelAdapterCapabilities()
 
     def __init__(self) -> None:
         """Initialize base ModelAdapter.
 
-        Note: This is an abstract base class. Subclasses must override this
-        method to set:
-        - self.ocean_model: Name of the ocean model (str)
-        - self.time_varname: Name of the time variable in model files (str)
+        Note: Subclasses should define ocean_model and time_varname as class attributes rather 
+        than setting them in __init__.
         """
-        pass  # Subclasses must implement
+        if not hasattr(self.__class__, 'ocean_model') or self.__class__.ocean_model is None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} must define 'ocean_model' as a class attribute."
+            )
+        if not hasattr(self.__class__, 'time_varname') or self.__class__.time_varname is None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} must define 'time_varname' as a class attribute"
+            )
 
     @contextmanager
     def open_dataset_ctx(self, path: str) -> Iterator[xr.Dataset]:

--- a/crococamp/model_adapter/model_adapter_MOM6.py
+++ b/crococamp/model_adapter/model_adapter_MOM6.py
@@ -14,19 +14,14 @@ class ModelAdapterMOM6(ModelAdapter):
 
     Provides common functionality for model input normalization.
     """
+    ocean_model = "MOM6"
+    time_varname = "time"
+
     capabilities = ModelAdapterCapabilities(
         supports_trim_obs = True,
         supports_no_matching = True,
         supports_force_obs_time = True
     )
-
-    def __init__(self) -> None:
-
-        # Assign ocean model name
-        self.ocean_model = "MOM6"
-        # Assign time_variable_name
-        self.time_varname = "time"
-        return
 
     def get_required_config_keys(self) -> List[str]:
         """Return list of required configuration keys.

--- a/crococamp/model_adapter/model_adapter_ROMS_Rutgers.py
+++ b/crococamp/model_adapter/model_adapter_ROMS_Rutgers.py
@@ -14,20 +14,14 @@ class ModelAdapterROMSRutgers(ModelAdapter):
 
     Provides common functionality for model input normalization.
     """
+    ocean_model = "ROMS_Rutgers"
+    time_varname = "ocean_time"
 
     capabilities = ModelAdapterCapabilities(
         supports_trim_obs = False,
         supports_no_matching = False,
         supports_force_obs_time = False
     )
-
-    def __init__(self) -> None:
-
-        # Assign ocean model name
-        self.ocean_model = "ROMS_Rutgers"
-        # Assign time_varname_name
-        self.time_varname = "ocean_time"
-        return
 
     def get_required_config_keys(self) -> List[str]:
         """Return list of required configuration keys.


### PR DESCRIPTION
Refactors ModelAdapter classes to use class attributes instead of instance attributes for `ocean_model` and `time_varname`.

## Changes
- Modified base `ModelAdapter` class to declare `ocean_model` and `time_varname` as class attributes
- Added validation in `ModelAdapter.__init__` to ensure subclasses define these attributes
- Refactored `ModelAdapterMOM6` to use class attributes
- Refactored `ModelAdapterROMSRutgers` to use class attributes
- Updated docstrings

Fixes #51
